### PR TITLE
changed config_path to 'cfg/yolo.cfg'

### DIFF
--- a/yad2k.py
+++ b/yad2k.py
@@ -61,7 +61,7 @@ def unique_config_sections(config_file):
 
 
 def _main(args):
-    config_path = os.path.expanduser(args.config_path)
+    config_path = 'cfg/yolo.cfg'
     weights_path = os.path.expanduser(args.weights_path)
     assert config_path.endswith('.cfg'), '{} is not a .cfg file'.format(
         config_path)


### PR DESCRIPTION
**!Error occurred when reading the yolo.cfg file**
variable config_path which was taken from parser.parse_args() misses a '/' in its path('cfgyolo.cfg').
fixed that issue by changing the config_path variable to the cfg file path. Hope this would be helpful if any other got the same error