### PR TITLE
Add custom model path to YOLO class.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Misc
+yolov3.weights
+data/yolo.h5
+.DS_Store

--- a/model/yolo_model.py
+++ b/model/yolo_model.py
@@ -6,7 +6,7 @@ from keras.models import load_model
 
 
 class YOLO:
-    def __init__(self, obj_threshold, nms_threshold):
+    def __init__(self, obj_threshold, nms_threshold, model_path='data/yolo.h5'):
         """Init.
 
         # Arguments
@@ -15,7 +15,7 @@ class YOLO:
         """
         self._t1 = obj_threshold
         self._t2 = nms_threshold
-        self._yolo = load_model('data/yolo.h5')
+        self._yolo = load_model(model_path)
 
     def _sigmoid(self, x):
         """sigmoid.


### PR DESCRIPTION
When using this repo as a submodule, the model path is taken as relative and does not exist in the proper location. Adding support to specify a custom model path.